### PR TITLE
Updating 50-org to conform to the Updated Data schemas

### DIFF
--- a/models/agencies.py
+++ b/models/agencies.py
@@ -1,0 +1,133 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any, Union
+from .common import PaginatedResponse
+
+
+class BaseAgency(BaseModel):
+    name: Optional[str] = Field(None, description="Name of the agency")
+    hq_address: Optional[str] = Field(None, description="Address of the agency")
+    hq_city: Optional[str] = Field(None, description="City of the agency")
+    hq_state: Optional[str] = Field(None, description="State of the agency")
+    hq_zip: Optional[str] = Field(None, description="Zip code of the agency")
+    jurisdiction: Optional[str] = Field(None, description="Jurisdiction of the agency")
+    phone: Optional[str] = Field(None, description="Phone number of the agency")
+    email: Optional[str] = Field(None, description="Email of the agency")
+    website_url: Optional[str] = Field(None, description="Website of the agency")
+
+
+class CreateAgency(BaseAgency, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the agency")
+    hq_address: Optional[str] = Field(None, description="Address of the agency")
+    hq_city: Optional[str] = Field(None, description="City of the agency")
+    hq_state: Optional[str] = Field(None, description="State of the agency")
+    hq_zip: Optional[str] = Field(None, description="Zip code of the agency")
+    jurisdiction: Optional[str] = Field(None, description="Jurisdiction of the agency")
+    phone: Optional[str] = Field(None, description="Phone number of the agency")
+    email: Optional[str] = Field(None, description="Email of the agency")
+    website_url: Optional[str] = Field(None, description="Website of the agency")
+
+
+class UpdateAgency(BaseAgency, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the agency")
+    hq_address: Optional[str] = Field(None, description="Address of the agency")
+    hq_city: Optional[str] = Field(None, description="City of the agency")
+    hq_state: Optional[str] = Field(None, description="State of the agency")
+    hq_zip: Optional[str] = Field(None, description="Zip code of the agency")
+    jurisdiction: Optional[str] = Field(None, description="Jurisdiction of the agency")
+    phone: Optional[str] = Field(None, description="Phone number of the agency")
+    email: Optional[str] = Field(None, description="Email of the agency")
+    website_url: Optional[str] = Field(None, description="Website of the agency")
+
+
+class Agency(BaseAgency, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the agency")
+    hq_address: Optional[str] = Field(None, description="Address of the agency")
+    hq_city: Optional[str] = Field(None, description="City of the agency")
+    hq_state: Optional[str] = Field(None, description="State of the agency")
+    hq_zip: Optional[str] = Field(None, description="Zip code of the agency")
+    jurisdiction: Optional[str] = Field(None, description="Jurisdiction of the agency")
+    phone: Optional[str] = Field(None, description="Phone number of the agency")
+    email: Optional[str] = Field(None, description="Email of the agency")
+    website_url: Optional[str] = Field(None, description="Website of the agency")
+    uid: Optional[str] = Field(None, description="Unique identifier for the agency")
+    officers_url: Optional[str] = Field(None, description="URL to get a list of officers for this agency")
+    units_url: Optional[str] = Field(None, description="URL to get a list of units for this agency")
+
+
+class AgencyList(PaginatedResponse, BaseModel):
+    results: Optional[List[Agency]] = None
+
+
+class BaseUnit(BaseModel):
+    """Base properties for a unit"""
+    name: Optional[str] = Field(None, description="Name of the unit")
+    website_url: Optional[str] = Field(None, description="Website of the unit")
+    phone: Optional[str] = Field(None, description="Phone number of the unit")
+    email: Optional[str] = Field(None, description="Email of the unit")
+    description: Optional[str] = Field(None, description="Description of the unit")
+    address: Optional[str] = Field(None, description="Street address of the unit")
+    zip: Optional[str] = Field(None, description="Zip code of the unit")
+    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+
+
+class CreateUnit(BaseUnit, BaseModel):
+    name: str = Field(..., description="Name of the unit")
+    website_url: Optional[str] = Field(None, description="Website of the unit")
+    phone: Optional[str] = Field(None, description="Phone number of the unit")
+    email: Optional[str] = Field(None, description="Email of the unit")
+    description: Optional[str] = Field(None, description="Description of the unit")
+    address: Optional[str] = Field(None, description="Street address of the unit")
+    zip: Optional[str] = Field(None, description="Zip code of the unit")
+    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+    commander_uid: Optional[str] = Field(None, description="The UID of the unit's current commander.")
+
+
+class UpdateUnit(BaseUnit, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the unit")
+    website_url: Optional[str] = Field(None, description="Website of the unit")
+    phone: Optional[str] = Field(None, description="Phone number of the unit")
+    email: Optional[str] = Field(None, description="Email of the unit")
+    description: Optional[str] = Field(None, description="Description of the unit")
+    address: Optional[str] = Field(None, description="Street address of the unit")
+    zip: Optional[str] = Field(None, description="Zip code of the unit")
+    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+    commander_uid: Optional[str] = Field(None, description="The UID of the unit's current commander.")
+
+
+class Unit(BaseUnit, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the unit")
+    website_url: Optional[str] = Field(None, description="Website of the unit")
+    phone: Optional[str] = Field(None, description="Phone number of the unit")
+    email: Optional[str] = Field(None, description="Email of the unit")
+    description: Optional[str] = Field(None, description="Description of the unit")
+    address: Optional[str] = Field(None, description="Street address of the unit")
+    zip: Optional[str] = Field(None, description="Zip code of the unit")
+    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+    uid: Optional[str] = Field(None, description="Unique identifier for the unit")
+    commander_history_url: Optional[str] = Field(None, description="-| URL that returns the past commanders of the unit and the period of their respective commands.")
+    agency_url: Optional[str] = Field(None, description="URL to get the agency that this unit belongs to.")
+    officers_url: Optional[str] = Field(None, description="URL to get a list of officers for this unit.")
+
+
+class UnitList(PaginatedResponse, BaseModel):
+    results: Optional[List[Unit]] = None
+
+
+class AddOfficer(BaseModel):
+    officer_uid: str = Field(..., description="The uid of the officer")
+    earliest_employment: Optional[str] = Field(None, description="The earliest date of employment")
+    latest_employment: Optional[str] = Field(None, description="The latest date of employment")
+    badge_number: str = Field(..., description="The badge number of the officer")
+    unit_uid: str = Field(..., description="The UID of the unit the officer is assigned to.")
+    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during their employment.")
+    commander: Optional[bool] = Field(None, description="-| If true, this officer will be added as the commander of the unit for the specified time period.")
+
+
+class AddOfficerList(BaseModel):
+    officers: List[AddOfficer] = ...
+
+
+class AddOfficerFailed(BaseModel):
+    officer_uid: Optional[str] = Field(None, description="The uid of the officer")
+    reason: Optional[str] = Field(None, description="The reason the employment record could not be added")
+

--- a/models/agencies.py
+++ b/models/agencies.py
@@ -77,7 +77,9 @@ class CreateUnit(BaseUnit, BaseModel):
     email: Optional[str] = Field(None, description="Email of the unit")
     description: Optional[str] = Field(None, description="Description of the unit")
     address: Optional[str] = Field(None, description="Street address of the unit")
-    zip: Optional[str] = Field(None, description="Zip code of the unit")
+    city: Optional[str] = Field(None, description="City of the unit's HQ")
+    zip: Optional[str] = Field(None, description="Zip code of the unit's HQ")
+    state: Optional[str] = Field(None, description="State of the unit's HQ")
     date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
     commander_uid: Optional[str] = Field(None, description="The UID of the unit's current commander.")
 

--- a/models/agencies.py
+++ b/models/agencies.py
@@ -1,5 +1,7 @@
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any, Union
+
 from .common import PaginatedResponse
 
 
@@ -50,8 +52,12 @@ class Agency(BaseAgency, BaseModel):
     email: Optional[str] = Field(None, description="Email of the agency")
     website_url: Optional[str] = Field(None, description="Website of the agency")
     uid: Optional[str] = Field(None, description="Unique identifier for the agency")
-    officers_url: Optional[str] = Field(None, description="URL to get a list of officers for this agency")
-    units_url: Optional[str] = Field(None, description="URL to get a list of units for this agency")
+    officers_url: Optional[str] = Field(
+        None, description="URL to get a list of officers for this agency"
+    )
+    units_url: Optional[str] = Field(
+        None, description="URL to get a list of units for this agency"
+    )
 
 
 class AgencyList(PaginatedResponse, BaseModel):
@@ -60,6 +66,7 @@ class AgencyList(PaginatedResponse, BaseModel):
 
 class BaseUnit(BaseModel):
     """Base properties for a unit"""
+
     name: Optional[str] = Field(None, description="Name of the unit")
     website_url: Optional[str] = Field(None, description="Website of the unit")
     phone: Optional[str] = Field(None, description="Phone number of the unit")
@@ -67,7 +74,10 @@ class BaseUnit(BaseModel):
     description: Optional[str] = Field(None, description="Description of the unit")
     address: Optional[str] = Field(None, description="Street address of the unit")
     zip: Optional[str] = Field(None, description="Zip code of the unit")
-    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+    date_established: Optional[str] = Field(
+        None,
+        description="The date that this unit was established by its parent agency.",
+    )
 
 
 class CreateUnit(BaseUnit, BaseModel):
@@ -80,8 +90,13 @@ class CreateUnit(BaseUnit, BaseModel):
     city: Optional[str] = Field(None, description="City of the unit's HQ")
     zip: Optional[str] = Field(None, description="Zip code of the unit's HQ")
     state: Optional[str] = Field(None, description="State of the unit's HQ")
-    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
-    commander_uid: Optional[str] = Field(None, description="The UID of the unit's current commander.")
+    date_established: Optional[str] = Field(
+        None,
+        description="The date that this unit was established by its parent agency.",
+    )
+    commander_uid: Optional[str] = Field(
+        None, description="The UID of the unit's current commander."
+    )
 
 
 class UpdateUnit(BaseUnit, BaseModel):
@@ -92,8 +107,13 @@ class UpdateUnit(BaseUnit, BaseModel):
     description: Optional[str] = Field(None, description="Description of the unit")
     address: Optional[str] = Field(None, description="Street address of the unit")
     zip: Optional[str] = Field(None, description="Zip code of the unit")
-    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
-    commander_uid: Optional[str] = Field(None, description="The UID of the unit's current commander.")
+    date_established: Optional[str] = Field(
+        None,
+        description="The date that this unit was established by its parent agency.",
+    )
+    commander_uid: Optional[str] = Field(
+        None, description="The UID of the unit's current commander."
+    )
 
 
 class Unit(BaseUnit, BaseModel):
@@ -104,11 +124,21 @@ class Unit(BaseUnit, BaseModel):
     description: Optional[str] = Field(None, description="Description of the unit")
     address: Optional[str] = Field(None, description="Street address of the unit")
     zip: Optional[str] = Field(None, description="Zip code of the unit")
-    date_established: Optional[str] = Field(None, description="The date that this unit was established by its parent agency.")
+    date_established: Optional[str] = Field(
+        None,
+        description="The date that this unit was established by its parent agency.",
+    )
     uid: Optional[str] = Field(None, description="Unique identifier for the unit")
-    commander_history_url: Optional[str] = Field(None, description="-| URL that returns the past commanders of the unit and the period of their respective commands.")
-    agency_url: Optional[str] = Field(None, description="URL to get the agency that this unit belongs to.")
-    officers_url: Optional[str] = Field(None, description="URL to get a list of officers for this unit.")
+    commander_history_url: Optional[str] = Field(
+        None,
+        description="-| URL that returns the past commanders of the unit and the period of their respective commands.",
+    )
+    agency_url: Optional[str] = Field(
+        None, description="URL to get the agency that this unit belongs to."
+    )
+    officers_url: Optional[str] = Field(
+        None, description="URL to get a list of officers for this unit."
+    )
 
 
 class UnitList(PaginatedResponse, BaseModel):
@@ -117,12 +147,24 @@ class UnitList(PaginatedResponse, BaseModel):
 
 class AddOfficer(BaseModel):
     officer_uid: str = Field(..., description="The uid of the officer")
-    earliest_employment: Optional[str] = Field(None, description="The earliest date of employment")
-    latest_employment: Optional[str] = Field(None, description="The latest date of employment")
+    earliest_employment: Optional[str] = Field(
+        None, description="The earliest date of employment"
+    )
+    latest_employment: Optional[str] = Field(
+        None, description="The latest date of employment"
+    )
     badge_number: str = Field(..., description="The badge number of the officer")
-    unit_uid: str = Field(..., description="The UID of the unit the officer is assigned to.")
-    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during their employment.")
-    commander: Optional[bool] = Field(None, description="-| If true, this officer will be added as the commander of the unit for the specified time period.")
+    unit_uid: str = Field(
+        ..., description="The UID of the unit the officer is assigned to."
+    )
+    highest_rank: Optional[str] = Field(
+        None,
+        description="The highest rank the officer has held during their employment.",
+    )
+    commander: Optional[bool] = Field(
+        None,
+        description="-| If true, this officer will be added as the commander of the unit for the specified time period.",
+    )
 
 
 class AddOfficerList(BaseModel):
@@ -131,5 +173,6 @@ class AddOfficerList(BaseModel):
 
 class AddOfficerFailed(BaseModel):
     officer_uid: Optional[str] = Field(None, description="The uid of the officer")
-    reason: Optional[str] = Field(None, description="The reason the employment record could not be added")
-
+    reason: Optional[str] = Field(
+        None, description="The reason the employment record could not be added"
+    )

--- a/models/common.py
+++ b/models/common.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any, Union
+
+
+class PaginatedResponse(BaseModel):
+    page: Optional[int] = Field(None, description="The current page number.")
+    per_page: Optional[int] = Field(None, description="The number of items per page.")
+    total: Optional[int] = Field(None, description="The total number of items.")

--- a/models/common.py
+++ b/models/common.py
@@ -1,5 +1,6 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any, Union
 
 
 class PaginatedResponse(BaseModel):

--- a/models/enums.py
+++ b/models/enums.py
@@ -1,21 +1,22 @@
 """Enumerations shared across multiple models are defined here."""
+
 from enum import Enum
 
 
 class Gender(str, Enum):
-    OTHER = 'Other'
-    MALE = 'Male'
-    FEMALE = 'Female'
+    OTHER = "Other"
+    MALE = "Male"
+    FEMALE = "Female"
 
 
 class Ethnicity(str, Enum):
-    UNKNOWN = 'Unknown'
-    WHITE = 'White'
-    BLACK_AFRICAN_AMERICAN = 'Black/African American'
-    AMERICAN_INDIAN_ALASKA_NATIVE = 'American Indian/Alaska Native'
-    ASIAN = 'Asian'
-    NATIVE_HAWAIIAN_PACIFIC_ISLANDER = 'Native Hawaiian/Pacific Islander'
-    HISPANIC_LATINO = 'Hispanic/Latino'
+    UNKNOWN = "Unknown"
+    WHITE = "White"
+    BLACK_AFRICAN_AMERICAN = "Black/African American"
+    AMERICAN_INDIAN_ALASKA_NATIVE = "American Indian/Alaska Native"
+    ASIAN = "Asian"
+    NATIVE_HAWAIIAN_PACIFIC_ISLANDER = "Native Hawaiian/Pacific Islander"
+    HISPANIC_LATINO = "Hispanic/Latino"
 
 
 class State(str, Enum):

--- a/models/enums.py
+++ b/models/enums.py
@@ -1,0 +1,75 @@
+"""Enumerations shared across multiple models are defined here."""
+from enum import Enum
+
+
+class Gender(str, Enum):
+    OTHER = 'Other'
+    MALE = 'Male'
+    FEMALE = 'Female'
+
+
+class Ethnicity(str, Enum):
+    UNKNOWN = 'Unknown'
+    WHITE = 'White'
+    BLACK_AFRICAN_AMERICAN = 'Black/African American'
+    AMERICAN_INDIAN_ALASKA_NATIVE = 'American Indian/Alaska Native'
+    ASIAN = 'Asian'
+    NATIVE_HAWAIIAN_PACIFIC_ISLANDER = 'Native Hawaiian/Pacific Islander'
+    HISPANIC_LATINO = 'Hispanic/Latino'
+
+
+class State(str, Enum):
+    AL = "AL"
+    AK = "AK"
+    AZ = "AZ"
+    AR = "AR"
+    CA = "CA"
+    CO = "CO"
+    CT = "CT"
+    DE = "DE"
+    FL = "FL"
+    GA = "GA"
+    HI = "HI"
+    ID = "ID"
+    IL = "IL"
+    IN = "IN"
+    IA = "IA"
+    KS = "KS"
+    KY = "KY"
+    LA = "LA"
+    ME = "ME"
+    MD = "MD"
+    MA = "MA"
+    MI = "MI"
+    MN = "MN"
+    MS = "MS"
+    MO = "MO"
+    MT = "MT"
+    NE = "NE"
+    NV = "NV"
+    NH = "NH"
+    NJ = "NJ"
+    NM = "NM"
+    NY = "NY"
+    NC = "NC"
+    ND = "ND"
+    OH = "OH"
+    OK = "OK"
+    OR = "OR"
+    PA = "PA"
+    RI = "RI"
+    SC = "SC"
+    SD = "SD"
+    TN = "TN"
+    TX = "TX"
+    UT = "UT"
+    VT = "VT"
+    VA = "VA"
+    WA = "WA"
+    WV = "WV"
+    WI = "WI"
+    WY = "WY"
+    DC = "DC"
+    PR = "PR"
+    VI = "VI"
+    GU = "GU"

--- a/models/officers.py
+++ b/models/officers.py
@@ -1,0 +1,115 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any, Union
+from .common import PaginatedResponse
+
+
+class StateId(BaseModel):
+    uid: Optional[str] = Field(None, description="The UUID of this state id")
+    state: Optional[str] = Field(None, description="The state of the state id")
+    id_name: Optional[str] = Field(None, description="The name of the id. For example, Tax ID, Driver's License, etc.")
+    value: Optional[str] = Field(None, description="The value of the id.")
+
+
+class BaseEmployment(BaseModel):
+    officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
+    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
+    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
+    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
+    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
+    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
+    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
+    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+
+
+class AddEmployment(BaseEmployment, BaseModel):
+    officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
+    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
+    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
+    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
+    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
+    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
+    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
+    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+
+
+class AddEmploymentFailed(BaseModel):
+    agency_uid: Optional[str] = Field(None, description="The uid of the agency that could not be added.")
+    reason: Optional[str] = Field(None, description="The reason the employment record could not be added")
+
+
+class AddEmploymentList(BaseModel):
+    agencies: Optional[List[AddEmployment]] = Field(None, description="The units to add to the officer's employment history.")
+
+
+class Employment(BaseEmployment, BaseModel):
+    officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
+    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
+    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
+    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
+    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
+    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
+    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
+    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+
+
+class AddEmploymentResponse(BaseModel):
+    created: List[Employment] = ...
+    failed: List[AddEmploymentFailed] = ...
+    total_created: int = ...
+    total_failed: int = ...
+
+
+class EmploymentList(PaginatedResponse, BaseModel):
+    results: Optional[List[Employment]] = None
+
+
+class BaseOfficer(BaseModel):
+    first_name: Optional[str] = Field(None, description="First name of the officer")
+    middle_name: Optional[str] = Field(None, description="Middle name of the officer")
+    last_name: Optional[str] = Field(None, description="Last name of the officer")
+    suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
+    ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
+    gender: Optional[str] = Field(None, description="The gender of the officer")
+    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
+    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+
+
+class CreateOfficer(BaseOfficer, BaseModel):
+    first_name: Optional[str] = Field(None, description="First name of the officer")
+    middle_name: Optional[str] = Field(None, description="Middle name of the officer")
+    last_name: Optional[str] = Field(None, description="Last name of the officer")
+    suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
+    ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
+    gender: Optional[str] = Field(None, description="The gender of the officer")
+    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
+    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+
+
+class UpdateOfficer(BaseOfficer, BaseModel):
+    first_name: Optional[str] = Field(None, description="First name of the officer")
+    middle_name: Optional[str] = Field(None, description="Middle name of the officer")
+    last_name: Optional[str] = Field(None, description="Last name of the officer")
+    suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
+    ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
+    gender: Optional[str] = Field(None, description="The gender of the officer")
+    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
+    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+
+
+class Officer(BaseOfficer, BaseModel):
+    first_name: Optional[str] = Field(None, description="First name of the officer")
+    middle_name: Optional[str] = Field(None, description="Middle name of the officer")
+    last_name: Optional[str] = Field(None, description="Last name of the officer")
+    suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
+    ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
+    gender: Optional[str] = Field(None, description="The gender of the officer")
+    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
+    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+    uid: Optional[str] = Field(None, description="The uid of the officer")
+    employment_history: Optional[str] = Field(None, description="A link to retrieve the employment history of the officer")
+    allegations: Optional[str] = Field(None, description="A link to retrieve the allegations against the officer")
+    litigation: Optional[str] = Field(None, description="A link to retrieve the litigation against the officer")
+
+
+class OfficerList(PaginatedResponse, BaseModel):
+    results: Optional[List[Officer]] = None

--- a/models/officers.py
+++ b/models/officers.py
@@ -1,55 +1,114 @@
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any, Union
+
 from .common import PaginatedResponse
 
 
 class StateId(BaseModel):
     uid: Optional[str] = Field(None, description="The UUID of this state id")
     state: Optional[str] = Field(None, description="The state of the state id")
-    id_name: Optional[str] = Field(None, description="The name of the id. For example, Tax ID, Driver's License, etc.")
+    id_name: Optional[str] = Field(
+        None,
+        description="The name of the id. For example, Tax ID, Driver's License, etc.",
+    )
     value: Optional[str] = Field(None, description="The value of the id.")
 
 
 class BaseEmployment(BaseModel):
     officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
-    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
-    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
-    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
-    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
-    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
-    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
-    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+    agency_uid: Optional[str] = Field(
+        None, description="The UID of the agency the officer is employed by."
+    )
+    unit_uid: Optional[str] = Field(
+        None, description="The UID of the unit the officer is assigned to."
+    )
+    earliest_employment: Optional[str] = Field(
+        None, description="The earliest known date of employment"
+    )
+    latest_employment: Optional[str] = Field(
+        None, description="The latest known date of employment"
+    )
+    badge_number: Optional[str] = Field(
+        None, description="The badge number of the officer"
+    )
+    highest_rank: Optional[str] = Field(
+        None,
+        description="The highest rank the officer has held during this employment.",
+    )
+    commander: Optional[bool] = Field(
+        None,
+        description="Indicates that the officer commanded the unit during this employment.",
+    )
 
 
 class AddEmployment(BaseEmployment, BaseModel):
     officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
-    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
-    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
-    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
-    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
-    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
-    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
-    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+    agency_uid: Optional[str] = Field(
+        None, description="The UID of the agency the officer is employed by."
+    )
+    unit_uid: Optional[str] = Field(
+        None, description="The UID of the unit the officer is assigned to."
+    )
+    earliest_employment: Optional[str] = Field(
+        None, description="The earliest known date of employment"
+    )
+    latest_employment: Optional[str] = Field(
+        None, description="The latest known date of employment"
+    )
+    badge_number: Optional[str] = Field(
+        None, description="The badge number of the officer"
+    )
+    highest_rank: Optional[str] = Field(
+        None,
+        description="The highest rank the officer has held during this employment.",
+    )
+    commander: Optional[bool] = Field(
+        None,
+        description="Indicates that the officer commanded the unit during this employment.",
+    )
 
 
 class AddEmploymentFailed(BaseModel):
-    agency_uid: Optional[str] = Field(None, description="The uid of the agency that could not be added.")
-    reason: Optional[str] = Field(None, description="The reason the employment record could not be added")
+    agency_uid: Optional[str] = Field(
+        None, description="The uid of the agency that could not be added."
+    )
+    reason: Optional[str] = Field(
+        None, description="The reason the employment record could not be added"
+    )
 
 
 class AddEmploymentList(BaseModel):
-    agencies: Optional[List[AddEmployment]] = Field(None, description="The units to add to the officer's employment history.")
+    agencies: Optional[List[AddEmployment]] = Field(
+        None, description="The units to add to the officer's employment history."
+    )
 
 
 class Employment(BaseEmployment, BaseModel):
     officer_uid: Optional[str] = Field(None, description="The UID of the officer.")
-    agency_uid: Optional[str] = Field(None, description="The UID of the agency the officer is employed by.")
-    unit_uid: Optional[str] = Field(None, description="The UID of the unit the officer is assigned to.")
-    earliest_employment: Optional[str] = Field(None, description="The earliest known date of employment")
-    latest_employment: Optional[str] = Field(None, description="The latest known date of employment")
-    badge_number: Optional[str] = Field(None, description="The badge number of the officer")
-    highest_rank: Optional[str] = Field(None, description="The highest rank the officer has held during this employment.")
-    commander: Optional[bool] = Field(None, description="Indicates that the officer commanded the unit during this employment.")
+    agency_uid: Optional[str] = Field(
+        None, description="The UID of the agency the officer is employed by."
+    )
+    unit_uid: Optional[str] = Field(
+        None, description="The UID of the unit the officer is assigned to."
+    )
+    earliest_employment: Optional[str] = Field(
+        None, description="The earliest known date of employment"
+    )
+    latest_employment: Optional[str] = Field(
+        None, description="The latest known date of employment"
+    )
+    badge_number: Optional[str] = Field(
+        None, description="The badge number of the officer"
+    )
+    highest_rank: Optional[str] = Field(
+        None,
+        description="The highest rank the officer has held during this employment.",
+    )
+    commander: Optional[bool] = Field(
+        None,
+        description="Indicates that the officer commanded the unit during this employment.",
+    )
 
 
 class AddEmploymentResponse(BaseModel):
@@ -70,8 +129,12 @@ class BaseOfficer(BaseModel):
     suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
     ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
     gender: Optional[str] = Field(None, description="The gender of the officer")
-    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
-    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+    date_of_birth: Optional[str] = Field(
+        None, description="The date of birth of the officer"
+    )
+    state_ids: Optional[List[StateId]] = Field(
+        None, description="The state ids of the officer"
+    )
 
 
 class CreateOfficer(BaseOfficer, BaseModel):
@@ -81,8 +144,12 @@ class CreateOfficer(BaseOfficer, BaseModel):
     suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
     ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
     gender: Optional[str] = Field(None, description="The gender of the officer")
-    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
-    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+    date_of_birth: Optional[str] = Field(
+        None, description="The date of birth of the officer"
+    )
+    state_ids: Optional[List[StateId]] = Field(
+        None, description="The state ids of the officer"
+    )
 
 
 class UpdateOfficer(BaseOfficer, BaseModel):
@@ -92,8 +159,12 @@ class UpdateOfficer(BaseOfficer, BaseModel):
     suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
     ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
     gender: Optional[str] = Field(None, description="The gender of the officer")
-    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
-    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+    date_of_birth: Optional[str] = Field(
+        None, description="The date of birth of the officer"
+    )
+    state_ids: Optional[List[StateId]] = Field(
+        None, description="The state ids of the officer"
+    )
 
 
 class Officer(BaseOfficer, BaseModel):
@@ -103,12 +174,22 @@ class Officer(BaseOfficer, BaseModel):
     suffix: Optional[str] = Field(None, description="Suffix of the officer's name")
     ethnicity: Optional[str] = Field(None, description="The ethnicity of the officer")
     gender: Optional[str] = Field(None, description="The gender of the officer")
-    date_of_birth: Optional[str] = Field(None, description="The date of birth of the officer")
-    state_ids: Optional[List[StateId]] = Field(None, description="The state ids of the officer")
+    date_of_birth: Optional[str] = Field(
+        None, description="The date of birth of the officer"
+    )
+    state_ids: Optional[List[StateId]] = Field(
+        None, description="The state ids of the officer"
+    )
     uid: Optional[str] = Field(None, description="The uid of the officer")
-    employment_history: Optional[str] = Field(None, description="A link to retrieve the employment history of the officer")
-    allegations: Optional[str] = Field(None, description="A link to retrieve the allegations against the officer")
-    litigation: Optional[str] = Field(None, description="A link to retrieve the litigation against the officer")
+    employment_history: Optional[str] = Field(
+        None, description="A link to retrieve the employment history of the officer"
+    )
+    allegations: Optional[str] = Field(
+        None, description="A link to retrieve the allegations against the officer"
+    )
+    litigation: Optional[str] = Field(
+        None, description="A link to retrieve the litigation against the officer"
+    )
 
 
 class OfficerList(PaginatedResponse, BaseModel):

--- a/models/partners.py
+++ b/models/partners.py
@@ -1,0 +1,61 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any, Union
+from .common import PaginatedResponse
+
+
+class BasePartner(BaseModel):
+    name: Optional[str] = Field(None, description="Name of the partner organization.")
+    url: Optional[str] = Field(None, description="Website URL of the partner.")
+    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+
+
+class CreatePartner(BasePartner, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the partner organization.")
+    url: Optional[str] = Field(None, description="Website URL of the partner.")
+    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+
+
+class UpdatePartner(BasePartner, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the partner organization.")
+    url: Optional[str] = Field(None, description="Website URL of the partner.")
+    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+
+
+class Partner(BasePartner, BaseModel):
+    name: Optional[str] = Field(None, description="Name of the partner organization.")
+    url: Optional[str] = Field(None, description="Website URL of the partner.")
+    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+    uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    members: Optional[str] = Field(None, description="Url to get all members of the partner.")
+    reported_incidents: Optional[str] = Field(None, description="Url to get all incidents reported by the partner.")
+
+
+class PartnerList(PaginatedResponse, BaseModel):
+    results: Optional[List[Partner]] = None
+
+
+class MemberBase(BaseModel):
+    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
+    role: Optional[str] = Field(None, description="Role of the user.")
+    is_active: Optional[bool] = Field(None, description="Whether the user is active.")
+
+
+class Member(MemberBase, BaseModel):
+    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
+    role: Optional[str] = Field(None, description="Role of the user.")
+    is_active: Optional[bool] = Field(None, description="Whether the user is active.")
+    uid: Optional[str] = Field(None, description="Unique identifier for the user.")
+    date_joined: Optional[str] = Field(None, description="Date the user joined the partner organizaation.")
+
+
+class AddMember(MemberBase, BaseModel):
+    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
+    role: Optional[str] = Field(None, description="Role of the user.")
+    is_active: Optional[bool] = Field(None, description="Whether the user is active.")
+
+
+class MemberList(PaginatedResponse, BaseModel):
+    results: Optional[List[Member]] = None

--- a/models/partners.py
+++ b/models/partners.py
@@ -1,33 +1,47 @@
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any, Union
+
 from .common import PaginatedResponse
 
 
 class BasePartner(BaseModel):
     name: Optional[str] = Field(None, description="Name of the partner organization.")
     url: Optional[str] = Field(None, description="Website URL of the partner.")
-    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+    contact_email: Optional[str] = Field(
+        None, description="Contact email for the partner organization."
+    )
 
 
 class CreatePartner(BasePartner, BaseModel):
     name: Optional[str] = Field(None, description="Name of the partner organization.")
     url: Optional[str] = Field(None, description="Website URL of the partner.")
-    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+    contact_email: Optional[str] = Field(
+        None, description="Contact email for the partner organization."
+    )
 
 
 class UpdatePartner(BasePartner, BaseModel):
     name: Optional[str] = Field(None, description="Name of the partner organization.")
     url: Optional[str] = Field(None, description="Website URL of the partner.")
-    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+    contact_email: Optional[str] = Field(
+        None, description="Contact email for the partner organization."
+    )
 
 
 class Partner(BasePartner, BaseModel):
     name: Optional[str] = Field(None, description="Name of the partner organization.")
     url: Optional[str] = Field(None, description="Website URL of the partner.")
-    contact_email: Optional[str] = Field(None, description="Contact email for the partner organization.")
+    contact_email: Optional[str] = Field(
+        None, description="Contact email for the partner organization."
+    )
     uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
-    members: Optional[str] = Field(None, description="Url to get all members of the partner.")
-    reported_incidents: Optional[str] = Field(None, description="Url to get all incidents reported by the partner.")
+    members: Optional[str] = Field(
+        None, description="Url to get all members of the partner."
+    )
+    reported_incidents: Optional[str] = Field(
+        None, description="Url to get all incidents reported by the partner."
+    )
 
 
 class PartnerList(PaginatedResponse, BaseModel):
@@ -35,23 +49,31 @@ class PartnerList(PaginatedResponse, BaseModel):
 
 
 class MemberBase(BaseModel):
-    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    partner_uid: Optional[str] = Field(
+        None, description="Unique identifier for the partner."
+    )
     user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
     role: Optional[str] = Field(None, description="Role of the user.")
     is_active: Optional[bool] = Field(None, description="Whether the user is active.")
 
 
 class Member(MemberBase, BaseModel):
-    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    partner_uid: Optional[str] = Field(
+        None, description="Unique identifier for the partner."
+    )
     user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
     role: Optional[str] = Field(None, description="Role of the user.")
     is_active: Optional[bool] = Field(None, description="Whether the user is active.")
     uid: Optional[str] = Field(None, description="Unique identifier for the user.")
-    date_joined: Optional[str] = Field(None, description="Date the user joined the partner organizaation.")
+    date_joined: Optional[str] = Field(
+        None, description="Date the user joined the partner organizaation."
+    )
 
 
 class AddMember(MemberBase, BaseModel):
-    partner_uid: Optional[str] = Field(None, description="Unique identifier for the partner.")
+    partner_uid: Optional[str] = Field(
+        None, description="Unique identifier for the partner."
+    )
     user_uid: Optional[str] = Field(None, description="Unique identifier for the user.")
     role: Optional[str] = Field(None, description="Role of the user.")
     is_active: Optional[bool] = Field(None, description="Whether the user is active.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.3
 Scrapy==2.11.2
+pydantic

--- a/scrapers/common/base_item.py
+++ b/scrapers/common/base_item.py
@@ -4,4 +4,8 @@ from datetime import UTC, datetime
 
 @dataclass(kw_only=True)
 class BaseItem:
+    url: str
+    model: str
+    data: dict
     scraped_at: datetime = datetime.now(UTC)
+    source: str = "Fifty-A.org"

--- a/scrapers/common/base_item.py
+++ b/scrapers/common/base_item.py
@@ -8,4 +8,4 @@ class BaseItem:
     model: str
     data: dict
     scraped_at: datetime = datetime.now(UTC)
-    source: str = "Fifty-A.org"
+    source: str = "50-a.org"

--- a/scrapers/fifty_a/fifty_a/items.py
+++ b/scrapers/fifty_a/fifty_a/items.py
@@ -6,16 +6,10 @@ from scrapers.common.base_item import BaseItem
 
 @dataclass
 class CommandItem(BaseItem):
-    name: str
-    url: str
+    pass
 
 
 @dataclass
 class OfficerItem(BaseItem):
-    url: str
-    name: str
-    badge: str
-    race: str
-    gender: str
-    complaints: List[dict]
-    age: str
+    employment: List[dict] = None
+    service_start: str = None

--- a/scrapers/fifty_a/fifty_a/items.py
+++ b/scrapers/fifty_a/fifty_a/items.py
@@ -3,9 +3,12 @@ from typing import List
 
 from scrapers.common.base_item import BaseItem
 
+AGENCY_UID = "54485f3cbe3e49229e3d091f0d12e882"
+
 
 @dataclass
 class CommandItem(BaseItem):
+    agency: str = AGENCY_UID
     pass
 
 

--- a/scrapers/fifty_a/fifty_a/settings.py
+++ b/scrapers/fifty_a/fifty_a/settings.py
@@ -25,7 +25,7 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 1
 # The download delay setting will honor only one of:
 # CONCURRENT_REQUESTS_PER_DOMAIN = 16
 # CONCURRENT_REQUESTS_PER_IP = 16
@@ -68,9 +68,9 @@ DOWNLOAD_DELAY = 3
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
-# AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_ENABLED = True
 # The initial download delay
-# AUTOTHROTTLE_START_DELAY = 5
+AUTOTHROTTLE_START_DELAY = 3
 # The maximum download delay to be set in case of high latencies
 # AUTOTHROTTLE_MAX_DELAY = 60
 # The average number of requests Scrapy should be sending in parallel to

--- a/scrapers/fifty_a/fifty_a/settings.py
+++ b/scrapers/fifty_a/fifty_a/settings.py
@@ -14,7 +14,7 @@ NEWSPIDER_MODULE = "fifty_a.spiders"
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-# USER_AGENT = "fifty_a (+http://www.yourdomain.com)"
+USER_AGENT = "NPDI/2.0 (+http://www.nationalpolicedata.org)"
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
@@ -25,7 +25,7 @@ ROBOTSTXT_OBEY = True
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-DOWNLOAD_DELAY = 1
+DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
 # CONCURRENT_REQUESTS_PER_DOMAIN = 16
 # CONCURRENT_REQUESTS_PER_IP = 16

--- a/scrapers/fifty_a/fifty_a/spiders/command.py
+++ b/scrapers/fifty_a/fifty_a/spiders/command.py
@@ -22,7 +22,7 @@ class CommandSpider(scrapy.Spider):
         commands = response.css("a.command::attr(href)").getall()
         logging.info(f"Found {len(commands)} units.")
         if self.test_mode and commands:
-            random.shuffle(commands)
+            random.shuffle(commands)  # nosec
             commands = commands[: self.max_units]
         for command in commands:
             yield response.follow(command, self.parse_command)

--- a/scrapers/fifty_a/fifty_a/spiders/command.py
+++ b/scrapers/fifty_a/fifty_a/spiders/command.py
@@ -1,6 +1,10 @@
+import re
+import random
+import logging
 import scrapy
 
 from scrapers.fifty_a.fifty_a.items import CommandItem
+from models.agencies import CreateUnit
 
 
 class CommandSpider(scrapy.Spider):
@@ -8,11 +12,66 @@ class CommandSpider(scrapy.Spider):
     allowed_domains = ["www.50-a.org"]
     start_urls = ["https://www.50-a.org/commands"]
 
-    def parse(self, response):
-        for c in response.css("a.command"):
-            url = c.css("::attr(href)").extract_first()
-            command = CommandItem(
-                name=c.css("::text").extract_first(), url=response.urljoin(url)
-            )
+    def __init__(self, *args, **kwargs):
+        super(CommandSpider, self).__init__(*args, **kwargs)
+        self.test_mode = "test_mode" in kwargs
+        self.max_units = int(kwargs.get("max_units", 10))
 
-            yield command
+    def parse(self, response):
+        commands = response.css("a.command::attr(href)").getall()
+        logging.info(f"Found {len(commands)} units.")
+        if self.test_mode and commands:
+            random.shuffle(commands)
+            commands = commands[:self.max_units]
+        for command in commands:
+            yield response.follow(command, self.parse_command)
+
+    def parse_command(self, response):
+        description_set = [desc.strip() for desc in response.css("div.intro p::text").getall() if desc.strip()]
+        try:
+            desc = description_set[-1]
+        except IndexError:
+            desc = None
+            logging.info(f"Failed to extract description for {response.url}")
+
+        address_data = {}
+        address = response.css("div.intro a[href*='google.com']::text").get()
+        if address is not None:
+            address_data = self.parse_address(address)
+
+        command_data = {k: v for k, v in {
+            "name": response.css("h1.title.command::text").get().strip(),  # Extract the unit name from the h1 tag
+            "website_url": response.css("div.links a[href*='nypd']::attr(href)").get(),  # Extract the website URL, assuming it contains 'nypd'
+            "phone": response.css("div.links p::text").re_first(r"\(\d{3}\) \d{3}-\d{4}"),  # Extract the phone number
+            "description": desc,
+            "address": address_data.get("street"),
+            "city": address_data.get("city"),
+            "state": address_data.get("state"),
+            "zip": address_data.get("zip_code"),
+            "commander_uid": response.css("div.intro a[href*='/officer/']::attr(href)").get(),
+        }.items() if v is not None}
+
+        try:
+            unit = CreateUnit(**command_data)
+            yield unit.model_dump()
+        except ValueError as e:
+            logging.error(f"Validation error for unit {command_data['name']}: {e}")
+            return None
+
+    def parse_address(self, address):
+        """Parse the address into its components:
+        Street, City, State, Zip
+        """
+        address_pattern = r"^(.*?),\s*(.*?),\s*([A-Z]{2})\s*(\d{5})$"
+        match = re.match(address_pattern, address)
+        if match:
+            street, city, state, zip_code = match.groups()
+            return {
+                "street": street,
+                "city": city,
+                "state": state,
+                "zip_code": zip_code
+            }
+        else:
+            logging.error(f"Failed to parse address: {address}")
+            return None

--- a/scrapers/fifty_a/fifty_a/spiders/officer.py
+++ b/scrapers/fifty_a/fifty_a/spiders/officer.py
@@ -36,7 +36,7 @@ class OfficerSpider(CrawlSpider):
     def parse_start_url(self, response):
         commands = response.css("a.command::attr(href)").getall()
         if self.test_mode and commands:
-            selected_command = random.choice(commands)
+            selected_command = random.choice(commands)  # nosec
             yield response.follow(selected_command, self.parse_command)
         elif not self.test_mode:
             for command in commands:
@@ -47,7 +47,7 @@ class OfficerSpider(CrawlSpider):
         logging.info(f"Found {len(officer_links)} officers in {response.url}")
 
         if self.test_mode:
-            random.shuffle(officer_links)
+            random.shuffle(officer_links)  # nosec
             officer_links = officer_links[: self.max_officers]
 
         for officer_link in officer_links:

--- a/scrapers/fifty_a/fifty_a/spiders/officer.py
+++ b/scrapers/fifty_a/fifty_a/spiders/officer.py
@@ -10,7 +10,7 @@ from scrapy.spiders import CrawlSpider, Rule
 from models.enums import Ethnicity
 from models.officers import CreateOfficer, StateId
 from scrapers.common.parse import parse_string_to_number
-from scrapers.fifty_a.fifty_a.items import OfficerItem, AGENCY_UID
+from scrapers.fifty_a.fifty_a.items import AGENCY_UID, OfficerItem
 
 
 class OfficerSpider(CrawlSpider):
@@ -99,10 +99,7 @@ class OfficerSpider(CrawlSpider):
 
         prev_employment = response.css("div.commandhistory a::attr(href)").getall()
         for emp in prev_employment:
-            employment_history.append({
-                "unit_uid": emp,
-                "agency_uid": AGENCY_UID
-            })
+            employment_history.append({"unit_uid": emp, "agency_uid": AGENCY_UID})
 
         try:
             officer = CreateOfficer(**officer_data)

--- a/scrapers/fifty_a/fifty_a/spiders/officer.py
+++ b/scrapers/fifty_a/fifty_a/spiders/officer.py
@@ -137,7 +137,7 @@ class OfficerSpider(CrawlSpider):
             parts = description.split()
             if len(parts) >= 2:
                 ethnicity = parts[0]
-                gender = parts[1]
+                gender = parts[1].strip(",")
                 return ethnicity, gender
         return None, None
 

--- a/tests/fifty_a/fifty_a/spiders/command_page.py
+++ b/tests/fifty_a/fifty_a/spiders/command_page.py
@@ -9,9 +9,9 @@ command_1 = b"""
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
           integrity="sha384-HmYpsz2Aa9Gh3JlkCoh8kUJ2mUKJKTnkyC2Lzt8aLzpPOpnDe8KpFE2xNiBpMDou" crossorigin="anonymous">
     <link rel="stylesheet" href="/style.css">
-    
+
     <link rel="canonical" href="https://www.50-a.org/command/9pct">
-    
+
     <style>
       section.section form.search {
         margin-top: 2em;
@@ -32,7 +32,7 @@ command_1 = b"""
 
   <body>
     <header>
-      
+
       <form action="/search" method="GET">
         <label for="q" class="label">Search by Officer Name or Badge Number</label>
         <div class="field has-addons">
@@ -109,7 +109,7 @@ command_1 = b"""
               <a class="name"
                  href="/officer/X83Z"
                  title="Police Officer Jason Wu #14380"
-                 >Wu, Jason 
+                 >Wu, Jason
                 &nbsp; <span class="is-hidden-mobile">#14380</span>
               </a>
             </td>
@@ -122,7 +122,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -142,7 +142,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -162,14 +162,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/3W8K"
                  title="Police Officer Renaud Richardson #26372"
-                 >Richardson, Renaud 
+                 >Richardson, Renaud
                 &nbsp; <span class="is-hidden-mobile">#26372</span>
               </a>
             </td>
@@ -182,7 +182,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -202,7 +202,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -222,7 +222,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -242,7 +242,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -262,7 +262,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -282,7 +282,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -302,7 +302,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2024
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -322,7 +322,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -342,7 +342,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -362,14 +362,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/LRSH"
                  title="Sergeant Thomas Walsh #843"
-                 >Walsh, Thomas 
+                 >Walsh, Thomas
                 &nbsp; <span class="is-hidden-mobile">#843</span>
               </a>
             </td>
@@ -382,7 +382,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -402,7 +402,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -422,7 +422,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -442,7 +442,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -462,14 +462,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/EYCR"
                  title="Police Officer Sharandeep Singh #27965"
-                 >Singh, Sharandeep 
+                 >Singh, Sharandeep
                 &nbsp; <span class="is-hidden-mobile">#27965</span>
               </a>
             </td>
@@ -482,7 +482,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -502,7 +502,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -522,7 +522,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -542,7 +542,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -562,7 +562,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -582,7 +582,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -602,7 +602,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -622,7 +622,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -642,7 +642,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2023
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -662,7 +662,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -682,7 +682,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -702,7 +702,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -722,7 +722,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -742,7 +742,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -762,14 +762,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/KEQD"
                  title="Sergeant Arsenio Berrios #1128"
-                 >Berrios, Arsenio 
+                 >Berrios, Arsenio
                 &nbsp; <span class="is-hidden-mobile">#1128</span>
               </a>
             </td>
@@ -782,14 +782,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/ULP9"
                  title="Police Officer Amritpreet Sandhu #24256"
-                 >Sandhu, Amritpreet 
+                 >Sandhu, Amritpreet
                 &nbsp; <span class="is-hidden-mobile">#24256</span>
               </a>
             </td>
@@ -802,14 +802,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/V9K3"
                  title="Lieutenant Ronaldy Ventura"
-                 >Ventura, Ronaldy 
+                 >Ventura, Ronaldy
                 &nbsp; <span class="is-hidden-mobile"></span>
               </a>
             </td>
@@ -822,7 +822,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -842,14 +842,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/9UK7"
                  title="Police Officer Rafael Delacruz #23487"
-                 >Delacruz, Rafael 
+                 >Delacruz, Rafael
                 &nbsp; <span class="is-hidden-mobile">#23487</span>
               </a>
             </td>
@@ -862,14 +862,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2022
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/C92P"
                  title="Police Officer Lisandro Rodriguez #9145"
-                 >Rodriguez, Lisandro 
+                 >Rodriguez, Lisandro
                 &nbsp; <span class="is-hidden-mobile">#9145</span>
               </a>
             </td>
@@ -882,7 +882,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2021
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -902,7 +902,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2021
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -922,7 +922,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2021
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -942,14 +942,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2020
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/76EB"
                  title="Sergeant Robert Garcia #2393"
-                 >Garcia, Robert 
+                 >Garcia, Robert
                 &nbsp; <span class="is-hidden-mobile">#2393</span>
               </a>
             </td>
@@ -962,7 +962,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2020
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -982,14 +982,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2020
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/KUHB"
                  title="Police Officer Alex Adames #1118"
-                 >Adames, Alex 
+                 >Adames, Alex
                 &nbsp; <span class="is-hidden-mobile">#1118</span>
               </a>
             </td>
@@ -1002,14 +1002,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2020
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/9R6F"
                  title="Police Officer Yvener Cesar #5137"
-                 >Cesar, Yvener 
+                 >Cesar, Yvener
                 &nbsp; <span class="is-hidden-mobile">#5137</span>
               </a>
             </td>
@@ -1022,7 +1022,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2019
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1042,7 +1042,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2019
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1062,7 +1062,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2019
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1082,14 +1082,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2019
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/DURZ"
                  title="Sergeant Vlad Kogan #1999"
-                 >Kogan, Vlad 
+                 >Kogan, Vlad
                 &nbsp; <span class="is-hidden-mobile">#1999</span>
               </a>
             </td>
@@ -1102,7 +1102,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2019
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1122,7 +1122,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2018
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1142,7 +1142,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2018
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1162,14 +1162,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2018
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/V4AB"
                  title="Police Officer Takkeung Wong #1298"
-                 >Wong, Takkeung 
+                 >Wong, Takkeung
                 &nbsp; <span class="is-hidden-mobile">#1298</span>
               </a>
             </td>
@@ -1182,14 +1182,14 @@ command_1 = b"""
             <td class="year has-text-right">
               2018
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/QJL5"
                  title="Sergeant Magna Kamarasherif #427"
-                 >Kamarasherif, Magna 
+                 >Kamarasherif, Magna
                 &nbsp; <span class="is-hidden-mobile">#427</span>
               </a>
             </td>
@@ -1202,7 +1202,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2017
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1222,7 +1222,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2015
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1242,7 +1242,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2015
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1262,7 +1262,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2013
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1282,7 +1282,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2012
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1302,7 +1302,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2011
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1322,7 +1322,7 @@ command_1 = b"""
             <td class="year has-text-right">
               2011
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1340,9 +1340,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1360,16 +1360,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/LBBP"
                  title="Sergeant Andrews Adjei #1056"
-                 >Adjei, Andrews 
+                 >Adjei, Andrews
                 &nbsp; <span class="is-hidden-mobile">#1056</span>
               </a>
             </td>
@@ -1380,9 +1380,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1400,9 +1400,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1420,9 +1420,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1440,16 +1440,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/SK9H"
                  title="Police Officer Wael Baseluos #6796"
-                 >Baseluos, Wael 
+                 >Baseluos, Wael
                 &nbsp; <span class="is-hidden-mobile">#6796</span>
               </a>
             </td>
@@ -1460,9 +1460,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1480,9 +1480,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1500,9 +1500,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1520,9 +1520,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1540,16 +1540,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/ABWF"
                  title="Police Officer Mathew Brown #22202"
-                 >Brown, Mathew 
+                 >Brown, Mathew
                 &nbsp; <span class="is-hidden-mobile">#22202</span>
               </a>
             </td>
@@ -1560,9 +1560,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1580,9 +1580,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1600,9 +1600,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1620,9 +1620,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1640,9 +1640,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1660,16 +1660,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/U7CZ"
                  title="Police Officer Bryan Diaz #11127"
-                 >Diaz, Bryan 
+                 >Diaz, Bryan
                 &nbsp; <span class="is-hidden-mobile">#11127</span>
               </a>
             </td>
@@ -1680,9 +1680,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1700,9 +1700,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1720,9 +1720,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1740,16 +1740,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/334R"
                  title="Police Officer Rafael Espino #31805"
-                 >Espino, Rafael 
+                 >Espino, Rafael
                 &nbsp; <span class="is-hidden-mobile">#31805</span>
               </a>
             </td>
@@ -1760,16 +1760,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/LH7T"
                  title="Sergeant Woodley Etienne #2660"
-                 >Etienne, Woodley 
+                 >Etienne, Woodley
                 &nbsp; <span class="is-hidden-mobile">#2660</span>
               </a>
             </td>
@@ -1780,9 +1780,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1800,9 +1800,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1820,9 +1820,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1840,9 +1840,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1860,9 +1860,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1880,9 +1880,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1900,9 +1900,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1920,9 +1920,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1940,9 +1940,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -1960,16 +1960,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/H4M5"
                  title="Police Officer Tabatha Jehhar #17060"
-                 >Jehhar, Tabatha 
+                 >Jehhar, Tabatha
                 &nbsp; <span class="is-hidden-mobile">#17060</span>
               </a>
             </td>
@@ -1980,9 +1980,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2000,9 +2000,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2020,16 +2020,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/E6UH"
                  title="Sergeant Joel Kwok #3823"
-                 >Kwok, Joel 
+                 >Kwok, Joel
                 &nbsp; <span class="is-hidden-mobile">#3823</span>
               </a>
             </td>
@@ -2040,16 +2040,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/QUFR"
                  title="Sergeant Zijian Lao #2546"
-                 >Lao, Zijian 
+                 >Lao, Zijian
                 &nbsp; <span class="is-hidden-mobile">#2546</span>
               </a>
             </td>
@@ -2060,9 +2060,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2080,16 +2080,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/69LR"
                  title="Police Officer Angelina Lebronsantiago #1631"
-                 >Lebronsantiago, Angelina 
+                 >Lebronsantiago, Angelina
                 &nbsp; <span class="is-hidden-mobile">#1631</span>
               </a>
             </td>
@@ -2100,9 +2100,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2120,9 +2120,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2140,9 +2140,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2160,9 +2160,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2180,9 +2180,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2200,9 +2200,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2220,9 +2220,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2240,9 +2240,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2260,9 +2260,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2280,16 +2280,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/FNEZ"
                  title="Police Officer Jhonstyn Menasanchez #7764"
-                 >Menasanchez, Jhonstyn 
+                 >Menasanchez, Jhonstyn
                 &nbsp; <span class="is-hidden-mobile">#7764</span>
               </a>
             </td>
@@ -2300,9 +2300,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2320,9 +2320,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2340,9 +2340,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2360,16 +2360,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/F49R"
                  title="Police Officer Julie Ng #533"
-                 >Ng, Julie 
+                 >Ng, Julie
                 &nbsp; <span class="is-hidden-mobile">#533</span>
               </a>
             </td>
@@ -2380,9 +2380,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2400,9 +2400,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2420,9 +2420,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2440,9 +2440,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2460,9 +2460,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2480,9 +2480,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2500,16 +2500,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/MZ6H"
                  title="Police Officer Mariolys Ramirezrosario #9762"
-                 >Ramirezrosario, Mariolys 
+                 >Ramirezrosario, Mariolys
                 &nbsp; <span class="is-hidden-mobile">#9762</span>
               </a>
             </td>
@@ -2520,9 +2520,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2540,9 +2540,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2560,9 +2560,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2580,9 +2580,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2600,9 +2600,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2620,9 +2620,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2640,9 +2640,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2660,9 +2660,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2680,16 +2680,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/CDKC"
                  title="Police Officer Ivette Serrano #979"
-                 >Serrano, Ivette 
+                 >Serrano, Ivette
                 &nbsp; <span class="is-hidden-mobile">#979</span>
               </a>
             </td>
@@ -2700,9 +2700,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2720,16 +2720,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/4CZD"
                  title="Police Officer John Siomkos #18465"
-                 >Siomkos, John 
+                 >Siomkos, John
                 &nbsp; <span class="is-hidden-mobile">#18465</span>
               </a>
             </td>
@@ -2740,9 +2740,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2760,9 +2760,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2780,9 +2780,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2800,9 +2800,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2820,9 +2820,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
@@ -2840,16 +2840,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/NEX5"
                  title="Police Officer Diego Valdovinosvaldovinos #1936"
-                 >Valdovinosvaldovinos, Diego 
+                 >Valdovinosvaldovinos, Diego
                 &nbsp; <span class="is-hidden-mobile">#1936</span>
               </a>
             </td>
@@ -2860,16 +2860,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/426H"
                  title="Police Officer Brian Vasquez #10701"
-                 >Vasquez, Brian 
+                 >Vasquez, Brian
                 &nbsp; <span class="is-hidden-mobile">#10701</span>
               </a>
             </td>
@@ -2880,16 +2880,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/DVS7"
                  title="Police Officer Anthony Wan #7268"
-                 >Wan, Anthony 
+                 >Wan, Anthony
                 &nbsp; <span class="is-hidden-mobile">#7268</span>
               </a>
             </td>
@@ -2900,16 +2900,16 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
           <tr>
             <td class="officer">
               <a class="name"
                  href="/officer/VHVM"
                  title="Police Officer Xiqian Yang #3067"
-                 >Yang, Xiqian 
+                 >Yang, Xiqian
                 &nbsp; <span class="is-hidden-mobile">#3067</span>
               </a>
             </td>
@@ -2920,9 +2920,9 @@ command_1 = b"""
               0
             </td>
             <td class="year has-text-right">
-              
+
             </td>
-            
+
           </tr>
         </tbody>
       </table>

--- a/tests/fifty_a/fifty_a/spiders/command_page.py
+++ b/tests/fifty_a/fifty_a/spiders/command_page.py
@@ -1,0 +1,2941 @@
+command_1 = b"""
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>9th Precinct : 50-a.org</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+          integrity="sha384-HmYpsz2Aa9Gh3JlkCoh8kUJ2mUKJKTnkyC2Lzt8aLzpPOpnDe8KpFE2xNiBpMDou" crossorigin="anonymous">
+    <link rel="stylesheet" href="/style.css">
+    
+    <link rel="canonical" href="https://www.50-a.org/command/9pct">
+    
+    <style>
+      section.section form.search {
+        margin-top: 2em;
+        margin-bottom: 2em;
+        max-width: 32em;
+      }
+      section.section,
+      header,
+      footer {
+        max-width: 769px;
+        margin: auto;
+      }
+      header, footer {
+        padding: 0.5em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      
+      <form action="/search" method="GET">
+        <label for="q" class="label">Search by Officer Name or Badge Number</label>
+        <div class="field has-addons">
+          <div class="control is-expanded">
+            <input class="input" type="text" id="q" name="q" value="" placeholder="enter name or badge #" required>
+          </div>
+          <div class="control">
+            <button class="button is-info" type="submit">Search</button>
+          </div>
+        </div>
+      </form>
+    </header>
+    <section class="section command">
+
+  <h1 class="title command">9th Precinct</h1>
+
+  <div class="container columns">
+    <div class="intro column is-three-quarters">
+      <p>
+        <span>Commanding Officer:</span>
+        Captain
+        <a href="/officer/HUHH">
+        Pamela
+        A.
+        Jeronimo
+        </a>
+      </p>
+      <a href="https://www.google.com/maps/search/?api&#x3D;1&amp;query&#x3D;NYPD%20Precinct&amp;query_place_id&#x3D;ChIJzVYrX3dZwokRA5yDIBJx1sg">321 E 5th St, New York, NY 10003</a>
+      <p>The 9th Precinct serves the area from East Houston Street to East 14 Street from Broadway, to the East River in Manhattan. The precinct is home to the East Village, and features Tompkins Square Park.</p>
+    </div>
+    <div class="links column">
+      <a href="https://www1.nyc.gov/site/nypd/bureaus/patrol/precincts/9th-precinct.page">Precinct Website</a><br />
+      <p>(212) 477-7812</p>
+      <a href="http://twitter.com/NYPD9Pct">Twitter @NYPD9Pct</a><br />
+      <a href="https://www.facebook.com/NYPD9pct/">Facebook</a>
+    </div>
+  </div>
+
+  <div class="container officers">
+
+
+
+    <table class="table is-narrow is-hoverable is-fullwidth">
+        <tbody>
+
+          <tr class="header">
+            <th class="officer ">
+              <a href="/command/9pct?sort=name_ac" title="sort by name">
+                Officer
+              </a>
+            </th>
+            <th class="allegation has-text-right wordbreak ">
+              <a href="/command/9pct?sort=allegations_dc" title="sort by allegation count">
+                Allegations
+              </a>
+            </th>
+            <th class="substantiated has-text-right wordbreak ">
+              <a href="/command/9pct?sort=substantiated_dc" title="sort by substantiated count">
+                Substantiated
+              </a>
+            </th>
+            <th class="recent has-text-right ">
+              <a href="/command/9pct?sort=recent_dc" title="sort by most recent complaint">
+                Most Recent
+              </a>
+            </th>
+            <th class="photo has-text-right is-hidden-mobile">
+              <a href="/command/9pct?image=on" title="show photos">&squ;</a>
+            </th>
+          </tr>
+
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/X83Z"
+                 title="Police Officer Jason Wu #14380"
+                 >Wu, Jason 
+                &nbsp; <span class="is-hidden-mobile">#14380</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              8
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/39R9"
+                 title="Police Officer Justin N. Chiarello #472"
+                 >Chiarello, Justin N.
+                &nbsp; <span class="is-hidden-mobile">#472</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/5P73"
+                 title="Police Officer Christian J. Lopez #2750"
+                 >Lopez, Christian J.
+                &nbsp; <span class="is-hidden-mobile">#2750</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/3W8K"
+                 title="Police Officer Renaud Richardson #26372"
+                 >Richardson, Renaud 
+                &nbsp; <span class="is-hidden-mobile">#26372</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              5
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/K9KD"
+                 title="Police Officer Daniel P. Altman #23431"
+                 >Altman, Daniel P.
+                &nbsp; <span class="is-hidden-mobile">#23431</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/YBRK"
+                 title="Lieutenant Alexander O. Hwang"
+                 >Hwang, Alexander O.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4C25"
+                 title="Police Officer Ekram M. Khan #26575"
+                 >Khan, Ekram M.
+                &nbsp; <span class="is-hidden-mobile">#26575</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/VPQT"
+                 title="Police Officer Dondre A. Coye #22578"
+                 >Coye, Dondre A.
+                &nbsp; <span class="is-hidden-mobile">#22578</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/A3ZM"
+                 title="Police Officer Eddie F. Gutierrez #9602"
+                 >Gutierrez, Eddie F.
+                &nbsp; <span class="is-hidden-mobile">#9602</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QHZ3"
+                 title="Sergeant Kit C. Yung #5493"
+                 >Yung, Kit C.
+                &nbsp; <span class="is-hidden-mobile">#5493</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              12
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2024
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/DZ4R"
+                 title="Police Officer Anyely D. Mejia #14763"
+                 >Mejia, Anyely D.
+                &nbsp; <span class="is-hidden-mobile">#14763</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/WLZ"
+                 title="Police Officer Brenden W. Rogers #2146"
+                 >Rogers, Brenden W.
+                &nbsp; <span class="is-hidden-mobile">#2146</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              7
+            </td>
+            <td class="substantiated has-text-right">
+              3
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4BSX"
+                 title="Police Officer Robert J. Ceci #28273"
+                 >Ceci, Robert J.
+                &nbsp; <span class="is-hidden-mobile">#28273</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              8
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/LRSH"
+                 title="Sergeant Thomas Walsh #843"
+                 >Walsh, Thomas 
+                &nbsp; <span class="is-hidden-mobile">#843</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              13
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CGWV"
+                 title="Sergeant Timur S. Popal #3631"
+                 >Popal, Timur S.
+                &nbsp; <span class="is-hidden-mobile">#3631</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              12
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QKNT"
+                 title="Police Officer Daniel D. Kafka #15326"
+                 >Kafka, Daniel D.
+                &nbsp; <span class="is-hidden-mobile">#15326</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/B7FZ"
+                 title="Police Officer Orlando R. Checo #13035"
+                 >Checo, Orlando R.
+                &nbsp; <span class="is-hidden-mobile">#13035</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/GETB"
+                 title="Sergeant Charsel J. Anthony #704"
+                 >Anthony, Charsel J.
+                &nbsp; <span class="is-hidden-mobile">#704</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              9
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/EYCR"
+                 title="Police Officer Sharandeep Singh #27965"
+                 >Singh, Sharandeep 
+                &nbsp; <span class="is-hidden-mobile">#27965</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KJ5F"
+                 title="Police Officer Gaileen R. Stapletongilgeours #13887"
+                 >Stapletongilgeours, Gaileen R.
+                &nbsp; <span class="is-hidden-mobile">#13887</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              6
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/HLHK"
+                 title="Police Officer David L. Bowman #16034"
+                 >Bowman, David L.
+                &nbsp; <span class="is-hidden-mobile">#16034</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              24
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/GU7F"
+                 title="Lieutenant Byung C. Cho"
+                 >Cho, Byung C.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              7
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/R3AT"
+                 title="Police Officer Zachary D. Agosto #16706"
+                 >Agosto, Zachary D.
+                &nbsp; <span class="is-hidden-mobile">#16706</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/F285"
+                 title="Police Officer Suzeth G. Quiroz #19410"
+                 >Quiroz, Suzeth G.
+                &nbsp; <span class="is-hidden-mobile">#19410</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KJ2M"
+                 title="Sergeant Jonathan D. Todman #5484"
+                 >Todman, Jonathan D.
+                &nbsp; <span class="is-hidden-mobile">#5484</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KNJ3"
+                 title="Police Officer Victor H. Yee #16906"
+                 >Yee, Victor H.
+                &nbsp; <span class="is-hidden-mobile">#16906</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              5
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SXCZ"
+                 title="Police Officer Keanu T. Vargas #6741"
+                 >Vargas, Keanu T.
+                &nbsp; <span class="is-hidden-mobile">#6741</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2023
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/PBTT"
+                 title="Police Officer Angelo H. Liu #8364"
+                 >Liu, Angelo H.
+                &nbsp; <span class="is-hidden-mobile">#8364</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CEBF"
+                 title="Police Officer Julio A. Ramos #18554"
+                 >Ramos, Julio A.
+                &nbsp; <span class="is-hidden-mobile">#18554</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/3YDB"
+                 title="Police Officer Kenri J. Joseph #26574"
+                 >Joseph, Kenri J.
+                &nbsp; <span class="is-hidden-mobile">#26574</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              5
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/X5U5"
+                 title="Police Officer Gino R. Guevara #2555"
+                 >Guevara, Gino R.
+                &nbsp; <span class="is-hidden-mobile">#2555</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/6CRZ"
+                 title="Police Officer Robert P. Stevens #25118"
+                 >Stevens, Robert P.
+                &nbsp; <span class="is-hidden-mobile">#25118</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/XDP"
+                 title="Police Officer Jose O. Torres #21912"
+                 >Torres, Jose O.
+                &nbsp; <span class="is-hidden-mobile">#21912</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KEQD"
+                 title="Sergeant Arsenio Berrios #1128"
+                 >Berrios, Arsenio 
+                &nbsp; <span class="is-hidden-mobile">#1128</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/ULP9"
+                 title="Police Officer Amritpreet Sandhu #24256"
+                 >Sandhu, Amritpreet 
+                &nbsp; <span class="is-hidden-mobile">#24256</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/V9K3"
+                 title="Lieutenant Ronaldy Ventura"
+                 >Ventura, Ronaldy 
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/N6HF"
+                 title="Sergeant Andre J. Michel #2637"
+                 >Michel, Andre J.
+                &nbsp; <span class="is-hidden-mobile">#2637</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/9UK7"
+                 title="Police Officer Rafael Delacruz #23487"
+                 >Delacruz, Rafael 
+                &nbsp; <span class="is-hidden-mobile">#23487</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2022
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/C92P"
+                 title="Police Officer Lisandro Rodriguez #9145"
+                 >Rodriguez, Lisandro 
+                &nbsp; <span class="is-hidden-mobile">#9145</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              6
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2021
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CWJ7"
+                 title="Police Officer Joshua H. Moye #27006"
+                 >Moye, Joshua H.
+                &nbsp; <span class="is-hidden-mobile">#27006</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2021
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/6EGP"
+                 title="Police Officer Thomas J. Gallagher #23752"
+                 >Gallagher, Thomas J.
+                &nbsp; <span class="is-hidden-mobile">#23752</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2021
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/3JSX"
+                 title="Sergeant Joseph F. Mauro #5196"
+                 >Mauro, Joseph F.
+                &nbsp; <span class="is-hidden-mobile">#5196</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2020
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/76EB"
+                 title="Sergeant Robert Garcia #2393"
+                 >Garcia, Robert 
+                &nbsp; <span class="is-hidden-mobile">#2393</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2020
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/59YV"
+                 title="Police Officer Louis C. Caputo #9330"
+                 >Caputo, Louis C.
+                &nbsp; <span class="is-hidden-mobile">#9330</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              7
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2020
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KUHB"
+                 title="Police Officer Alex Adames #1118"
+                 >Adames, Alex 
+                &nbsp; <span class="is-hidden-mobile">#1118</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2020
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/9R6F"
+                 title="Police Officer Yvener Cesar #5137"
+                 >Cesar, Yvener 
+                &nbsp; <span class="is-hidden-mobile">#5137</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2019
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/VSCV"
+                 title="Sergeant Matthew J. Mcgrath #2715"
+                 >Mcgrath, Matthew J.
+                &nbsp; <span class="is-hidden-mobile">#2715</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2019
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/XLNT"
+                 title="Police Officer Thomas J. Doyle #2912"
+                 >Doyle, Thomas J.
+                &nbsp; <span class="is-hidden-mobile">#2912</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2019
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/9CZZ"
+                 title="Police Officer Meglis E. Grullon #28159"
+                 >Grullon, Meglis E.
+                &nbsp; <span class="is-hidden-mobile">#28159</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              6
+            </td>
+            <td class="substantiated has-text-right">
+              1
+            </td>
+            <td class="year has-text-right">
+              2019
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/DURZ"
+                 title="Sergeant Vlad Kogan #1999"
+                 >Kogan, Vlad 
+                &nbsp; <span class="is-hidden-mobile">#1999</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              7
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2019
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/HY5R"
+                 title="Police Officer Edwin J. Peguero #24835"
+                 >Peguero, Edwin J.
+                &nbsp; <span class="is-hidden-mobile">#24835</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              10
+            </td>
+            <td class="substantiated has-text-right">
+              2
+            </td>
+            <td class="year has-text-right">
+              2018
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/9TDZ"
+                 title="Police Officer Joseph V. Wallach #24933"
+                 >Wallach, Joseph V.
+                &nbsp; <span class="is-hidden-mobile">#24933</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2018
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SDKM"
+                 title="Police Officer Miguel A. Jimenez #10055"
+                 >Jimenez, Miguel A.
+                &nbsp; <span class="is-hidden-mobile">#10055</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2018
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/V4AB"
+                 title="Police Officer Takkeung Wong #1298"
+                 >Wong, Takkeung 
+                &nbsp; <span class="is-hidden-mobile">#1298</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2018
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QJL5"
+                 title="Sergeant Magna Kamarasherif #427"
+                 >Kamarasherif, Magna 
+                &nbsp; <span class="is-hidden-mobile">#427</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2017
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8VZ3"
+                 title="Police Officer Michael A. Schemmel #8779"
+                 >Schemmel, Michael A.
+                &nbsp; <span class="is-hidden-mobile">#8779</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              3
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2015
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/3LK7"
+                 title="Captain Michael W. Lam"
+                 >Lam, Michael W.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              2
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2015
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SM7D"
+                 title="Lieutenant David A. Hyman"
+                 >Hyman, David A.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2013
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4QLB"
+                 title="Lieutenant Morgan F. Courgnaud"
+                 >Courgnaud, Morgan F.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              5
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2012
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/HUHH"
+                 title="Captain Pamela A. Jeronimo"
+                 >Jeronimo, Pamela A.
+                &nbsp; <span class="is-hidden-mobile"></span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              1
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2011
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/XMM5"
+                 title="Police Officer James R. Murray #19869"
+                 >Murray, James R.
+                &nbsp; <span class="is-hidden-mobile">#19869</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              4
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              2011
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SJRV"
+                 title="Police Officer Hesham M. Abouelseoud #4690"
+                 >Abouelseoud, Hesham M.
+                &nbsp; <span class="is-hidden-mobile">#4690</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/A87P"
+                 title="Police Officer Kevin J. Adames #28180"
+                 >Adames, Kevin J.
+                &nbsp; <span class="is-hidden-mobile">#28180</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/LBBP"
+                 title="Sergeant Andrews Adjei #1056"
+                 >Adjei, Andrews 
+                &nbsp; <span class="is-hidden-mobile">#1056</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/K4GV"
+                 title="Police Officer Arfan I. Ali #1120"
+                 >Ali, Arfan I.
+                &nbsp; <span class="is-hidden-mobile">#1120</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/JQXT"
+                 title="Police Officer Alyssa J. Alioto #21394"
+                 >Alioto, Alyssa J.
+                &nbsp; <span class="is-hidden-mobile">#21394</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/AK2V"
+                 title="Police Officer Gustavo A. Arismendipalma #636"
+                 >Arismendipalma, Gustavo A.
+                &nbsp; <span class="is-hidden-mobile">#636</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SK9H"
+                 title="Police Officer Wael Baseluos #6796"
+                 >Baseluos, Wael 
+                &nbsp; <span class="is-hidden-mobile">#6796</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/P7WT"
+                 title="Police Officer Dante D. Bello #1834"
+                 >Bello, Dante D.
+                &nbsp; <span class="is-hidden-mobile">#1834</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CMCR"
+                 title="Police Officer Gerard M. Benfield #22165"
+                 >Benfield, Gerard M.
+                &nbsp; <span class="is-hidden-mobile">#22165</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/9XBM"
+                 title="Police Officer Ryan J. Black #13497"
+                 >Black, Ryan J.
+                &nbsp; <span class="is-hidden-mobile">#13497</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QJW5"
+                 title="Police Officer Claudashler S. Bonaventure #25160"
+                 >Bonaventure, Claudashler S.
+                &nbsp; <span class="is-hidden-mobile">#25160</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/ABWF"
+                 title="Police Officer Mathew Brown #22202"
+                 >Brown, Mathew 
+                &nbsp; <span class="is-hidden-mobile">#22202</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/R3LH"
+                 title="Police Officer Christopher R. Carty #6709"
+                 >Carty, Christopher R.
+                &nbsp; <span class="is-hidden-mobile">#6709</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/3DUH"
+                 title="Police Officer Fred F. Chen #1268"
+                 >Chen, Fred F.
+                &nbsp; <span class="is-hidden-mobile">#1268</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/89EM"
+                 title="Police Officer Utsav P. Desai #19149"
+                 >Desai, Utsav P.
+                &nbsp; <span class="is-hidden-mobile">#19149</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/WWST"
+                 title="Police Officer Klarens H. Desir #22985"
+                 >Desir, Klarens H.
+                &nbsp; <span class="is-hidden-mobile">#22985</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/BB3M"
+                 title="Police Officer Trevor K. Desire #16841"
+                 >Desire, Trevor K.
+                &nbsp; <span class="is-hidden-mobile">#16841</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/U7CZ"
+                 title="Police Officer Bryan Diaz #11127"
+                 >Diaz, Bryan 
+                &nbsp; <span class="is-hidden-mobile">#11127</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/WUG5"
+                 title="Police Officer Andre M. Durant #4171"
+                 >Durant, Andre M.
+                &nbsp; <span class="is-hidden-mobile">#4171</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/J9C5"
+                 title="Police Officer Dillon W. Engels #24955"
+                 >Engels, Dillon W.
+                &nbsp; <span class="is-hidden-mobile">#24955</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/52KZ"
+                 title="Police Officer Jacqueline A. Eriksen #9587"
+                 >Eriksen, Jacqueline A.
+                &nbsp; <span class="is-hidden-mobile">#9587</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/334R"
+                 title="Police Officer Rafael Espino #31805"
+                 >Espino, Rafael 
+                &nbsp; <span class="is-hidden-mobile">#31805</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/LH7T"
+                 title="Sergeant Woodley Etienne #2660"
+                 >Etienne, Woodley 
+                &nbsp; <span class="is-hidden-mobile">#2660</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8NVK"
+                 title="Police Officer Joseph A. Gambino #17741"
+                 >Gambino, Joseph A.
+                &nbsp; <span class="is-hidden-mobile">#17741</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/FDQK"
+                 title="Police Officer Nicholas G. Giamarino #22739"
+                 >Giamarino, Nicholas G.
+                &nbsp; <span class="is-hidden-mobile">#22739</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/AVLD"
+                 title="Police Officer Kelvin A. Gomez #6377"
+                 >Gomez, Kelvin A.
+                &nbsp; <span class="is-hidden-mobile">#6377</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QY3Z"
+                 title="Police Officer Luis F. Gonzalez #940"
+                 >Gonzalez, Luis F.
+                &nbsp; <span class="is-hidden-mobile">#940</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/R9R3"
+                 title="Police Officer Allison A. Hall #29249"
+                 >Hall, Allison A.
+                &nbsp; <span class="is-hidden-mobile">#29249</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/RKQ5"
+                 title="Police Officer David N. Harvin #13536"
+                 >Harvin, David N.
+                &nbsp; <span class="is-hidden-mobile">#13536</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QGN9"
+                 title="Police Officer Md R. Hasan #16333"
+                 >Hasan, Md R.
+                &nbsp; <span class="is-hidden-mobile">#16333</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/J3AD"
+                 title="Police Officer Justin M. Heaning #12391"
+                 >Heaning, Justin M.
+                &nbsp; <span class="is-hidden-mobile">#12391</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4TCR"
+                 title="Police Officer Jamilet C. Holguin #12516"
+                 >Holguin, Jamilet C.
+                &nbsp; <span class="is-hidden-mobile">#12516</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/H4M5"
+                 title="Police Officer Tabatha Jehhar #17060"
+                 >Jehhar, Tabatha 
+                &nbsp; <span class="is-hidden-mobile">#17060</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/JREH"
+                 title="Sergeant Special Assignment James W. Keating #4284"
+                 >Keating, James W.
+                &nbsp; <span class="is-hidden-mobile">#4284</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/LGZV"
+                 title="Police Officer Md G. Khader #16231"
+                 >Khader, Md G.
+                &nbsp; <span class="is-hidden-mobile">#16231</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/E6UH"
+                 title="Sergeant Joel Kwok #3823"
+                 >Kwok, Joel 
+                &nbsp; <span class="is-hidden-mobile">#3823</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QUFR"
+                 title="Sergeant Zijian Lao #2546"
+                 >Lao, Zijian 
+                &nbsp; <span class="is-hidden-mobile">#2546</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/5YM9"
+                 title="Police Officer Raymond F. Layden #28985"
+                 >Layden, Raymond F.
+                &nbsp; <span class="is-hidden-mobile">#28985</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/69LR"
+                 title="Police Officer Angelina Lebronsantiago #1631"
+                 >Lebronsantiago, Angelina 
+                &nbsp; <span class="is-hidden-mobile">#1631</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8F3K"
+                 title="Police Officer Matthew J. Lisa #30655"
+                 >Lisa, Matthew J.
+                &nbsp; <span class="is-hidden-mobile">#30655</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SXG5"
+                 title="Police Officer Jose A. Lora #14960"
+                 >Lora, Jose A.
+                &nbsp; <span class="is-hidden-mobile">#14960</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/W5BH"
+                 title="Police Officer Brianna A. Lynn #330"
+                 >Lynn, Brianna A.
+                &nbsp; <span class="is-hidden-mobile">#330</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/7J3R"
+                 title="Police Officer Abutalib O. Maiwand #24732"
+                 >Maiwand, Abutalib O.
+                &nbsp; <span class="is-hidden-mobile">#24732</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8MV"
+                 title="Police Officer Daniel F. Maldonado #22048"
+                 >Maldonado, Daniel F.
+                &nbsp; <span class="is-hidden-mobile">#22048</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KQPR"
+                 title="Police Officer Matthew J. Marinaro #28435"
+                 >Marinaro, Matthew J.
+                &nbsp; <span class="is-hidden-mobile">#28435</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/WPY3"
+                 title="Police Officer Carlos J. Marmolejos #22272"
+                 >Marmolejos, Carlos J.
+                &nbsp; <span class="is-hidden-mobile">#22272</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/Q4JR"
+                 title="Police Officer Anjelica D. Matiz #9029"
+                 >Matiz, Anjelica D.
+                &nbsp; <span class="is-hidden-mobile">#9029</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/U2Q9"
+                 title="Police Officer James B. Mccarty #3198"
+                 >Mccarty, James B.
+                &nbsp; <span class="is-hidden-mobile">#3198</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/FNEZ"
+                 title="Police Officer Jhonstyn Menasanchez #7764"
+                 >Menasanchez, Jhonstyn 
+                &nbsp; <span class="is-hidden-mobile">#7764</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/HH89"
+                 title="Police Officer Michael A. Mesquita #6613"
+                 >Mesquita, Michael A.
+                &nbsp; <span class="is-hidden-mobile">#6613</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/KDUK"
+                 title="Sergeant Alec K. Mui #3890"
+                 >Mui, Alec K.
+                &nbsp; <span class="is-hidden-mobile">#3890</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/S25P"
+                 title="Police Officer Kristen A. Naimoli #24414"
+                 >Naimoli, Kristen A.
+                &nbsp; <span class="is-hidden-mobile">#24414</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/F49R"
+                 title="Police Officer Julie Ng #533"
+                 >Ng, Julie 
+                &nbsp; <span class="is-hidden-mobile">#533</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/MJS7"
+                 title="Police Officer Jennifer M. Orta #6905"
+                 >Orta, Jennifer M.
+                &nbsp; <span class="is-hidden-mobile">#6905</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/33PH"
+                 title="Police Officer Jose S. Pichardo #14289"
+                 >Pichardo, Jose S.
+                &nbsp; <span class="is-hidden-mobile">#14289</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/SYQR"
+                 title="Police Officer Robert E. Ploth #7819"
+                 >Ploth, Robert E.
+                &nbsp; <span class="is-hidden-mobile">#7819</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/PQJ3"
+                 title="Police Officer Michael J. Potenza #16766"
+                 >Potenza, Michael J.
+                &nbsp; <span class="is-hidden-mobile">#16766</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/NYZ9"
+                 title="Police Officer Michael A. Quero #12535"
+                 >Quero, Michael A.
+                &nbsp; <span class="is-hidden-mobile">#12535</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/TAGX"
+                 title="Police Officer Christopher K. Rail #23899"
+                 >Rail, Christopher K.
+                &nbsp; <span class="is-hidden-mobile">#23899</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/MZ6H"
+                 title="Police Officer Mariolys Ramirezrosario #9762"
+                 >Ramirezrosario, Mariolys 
+                &nbsp; <span class="is-hidden-mobile">#9762</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/LP9V"
+                 title="Police Officer Kimberlin M. Ramoscruz #17618"
+                 >Ramoscruz, Kimberlin M.
+                &nbsp; <span class="is-hidden-mobile">#17618</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/JWQH"
+                 title="Police Officer Imani B. Reese #27097"
+                 >Reese, Imani B.
+                &nbsp; <span class="is-hidden-mobile">#27097</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/YUV"
+                 title="Police Officer Steven M. Rivera #19926"
+                 >Rivera, Steven M.
+                &nbsp; <span class="is-hidden-mobile">#19926</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/QN8D"
+                 title="Police Officer Lemuel A. Rosadosuriel #18094"
+                 >Rosadosuriel, Lemuel A.
+                &nbsp; <span class="is-hidden-mobile">#18094</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/PSY7"
+                 title="Sergeant Joseph T. Runko #3790"
+                 >Runko, Joseph T.
+                &nbsp; <span class="is-hidden-mobile">#3790</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CRCV"
+                 title="Police Officer Ahmed H. Saad #18305"
+                 >Saad, Ahmed H.
+                &nbsp; <span class="is-hidden-mobile">#18305</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/Y2MZ"
+                 title="Police Officer Nydia C. Sanchez #599"
+                 >Sanchez, Nydia C.
+                &nbsp; <span class="is-hidden-mobile">#599</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/5G9H"
+                 title="Police Officer Justine A. Sellers #12443"
+                 >Sellers, Justine A.
+                &nbsp; <span class="is-hidden-mobile">#12443</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/CDKC"
+                 title="Police Officer Ivette Serrano #979"
+                 >Serrano, Ivette 
+                &nbsp; <span class="is-hidden-mobile">#979</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/ALZD"
+                 title="Police Officer Dawa D. Sherpa #22828"
+                 >Sherpa, Dawa D.
+                &nbsp; <span class="is-hidden-mobile">#22828</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4CZD"
+                 title="Police Officer John Siomkos #18465"
+                 >Siomkos, John 
+                &nbsp; <span class="is-hidden-mobile">#18465</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/4NU3"
+                 title="Police Officer Aretha A. Smith #7457"
+                 >Smith, Aretha A.
+                &nbsp; <span class="is-hidden-mobile">#7457</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8KRV"
+                 title="Police Officer Johnathan M. Smyth #26172"
+                 >Smyth, Johnathan M.
+                &nbsp; <span class="is-hidden-mobile">#26172</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/A5A9"
+                 title="Police Officer Christopher J. Soto #9772"
+                 >Soto, Christopher J.
+                &nbsp; <span class="is-hidden-mobile">#9772</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/7A9R"
+                 title="Police Officer Tristan J. Soto #27178"
+                 >Soto, Tristan J.
+                &nbsp; <span class="is-hidden-mobile">#27178</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/8JGX"
+                 title="Police Officer Kenneth J. Taylor #10177"
+                 >Taylor, Kenneth J.
+                &nbsp; <span class="is-hidden-mobile">#10177</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/NEX5"
+                 title="Police Officer Diego Valdovinosvaldovinos #1936"
+                 >Valdovinosvaldovinos, Diego 
+                &nbsp; <span class="is-hidden-mobile">#1936</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/426H"
+                 title="Police Officer Brian Vasquez #10701"
+                 >Vasquez, Brian 
+                &nbsp; <span class="is-hidden-mobile">#10701</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/DVS7"
+                 title="Police Officer Anthony Wan #7268"
+                 >Wan, Anthony 
+                &nbsp; <span class="is-hidden-mobile">#7268</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+          <tr>
+            <td class="officer">
+              <a class="name"
+                 href="/officer/VHVM"
+                 title="Police Officer Xiqian Yang #3067"
+                 >Yang, Xiqian 
+                &nbsp; <span class="is-hidden-mobile">#3067</span>
+              </a>
+            </td>
+            <td class="allegations has-text-right">
+              0
+            </td>
+            <td class="substantiated has-text-right">
+              0
+            </td>
+            <td class="year has-text-right">
+              
+            </td>
+            
+          </tr>
+        </tbody>
+      </table>
+
+  </div>
+
+</section>
+
+    <footer>
+      <a href="/">50-a.org</a> &mdash;
+      <a href="/about">About</a> &mdash;
+      <a href="https://www.nyc.gov/site/ccrb/complaints/file-a-complaint/file-online.page">File a complaint</a>
+    </footer>
+  </body>
+</html>
+"""

--- a/tests/fifty_a/fifty_a/spiders/test_command.py
+++ b/tests/fifty_a/fifty_a/spiders/test_command.py
@@ -26,14 +26,20 @@ class TestCommand:
             pytest.fail(f"Unit Data is invalid: {e}")
 
         assert valid_data.name == "9th Precinct"
-        assert valid_data.website_url == "https://www1.nyc.gov/" + \
-            "site/nypd/bureaus/patrol/precincts/9th-precinct.page"
+        assert (
+            valid_data.website_url
+            == "https://www1.nyc.gov/"
+            + "site/nypd/bureaus/patrol/precincts/9th-precinct.page"
+        )
         assert valid_data.phone == "(212) 477-7812"
-        assert valid_data.description == "The 9th Precinct serves " + \
-            "the area from East Houston Street to East 14 Street from " + \
-            "Broadway, to the East River in Manhattan. The precinct is" + \
-            " home to the East Village, and features Tompkins " + \
-            "Square Park."
+        assert (
+            valid_data.description
+            == "The 9th Precinct serves "
+            + "the area from East Houston Street to East 14 Street from "
+            + "Broadway, to the East River in Manhattan. The precinct is"
+            + " home to the East Village, and features Tompkins "
+            + "Square Park."
+        )
         assert valid_data.address == "321 E 5th St"
         assert valid_data.city == "New York"
         assert valid_data.state == "NY"

--- a/tests/fifty_a/fifty_a/spiders/test_command.py
+++ b/tests/fifty_a/fifty_a/spiders/test_command.py
@@ -1,18 +1,39 @@
+import pytest
 from scrapy.http import HtmlResponse
 
+from models.agencies import CreateUnit
 from scrapers.fifty_a.fifty_a.spiders.command import CommandSpider
-from tests.fifty_a.fifty_a.spiders.commands_page import page_1
+from tests.fifty_a.fifty_a.spiders.command_page import command_1
 
-mock_response = HtmlResponse(url="dummy-commands", body=page_1)
+mock_response = HtmlResponse(url="dummy-commands", body=command_1)
 
 
 class TestCommand:
-    def test_parse(self):
+    def test_parse_command(self):
         spider = CommandSpider()
-        results = [i for i in spider.parse(mock_response)]
+        results = [i for i in spider.parse_command(mock_response)]
 
-        assert len(results) == 489
+        assert len(results) == 1
 
-        first_result = results[0]
-        assert first_result.url == "/command/1pct"
-        assert first_result.name == "1st Precinct"
+        unit = results[0]
+        assert unit.url == mock_response.url
+        assert unit.model == "unit"
+        assert unit.source == "50-a.org"
+        
+        try:
+            valid_data = CreateUnit(**unit.data)
+        except ValueError as e:
+            pytest.fail(f"Unit Data is invalid: {e}")
+
+        assert valid_data.name == "9th Precinct"
+        assert valid_data.website_url == "https://www1.nyc.gov/site/nypd/bureaus/patrol/precincts/9th-precinct.page"
+        assert valid_data.phone == "(212) 477-7812"
+        assert valid_data.description == "The 9th Precinct serves the area from East Houston Street to East 14 Street from Broadway, to the East River in Manhattan. The precinct is home to the East Village, and features Tompkins Square Park."
+        assert valid_data.address == "321 E 5th St"
+        assert valid_data.city == "New York"
+        assert valid_data.state == "NY"
+        assert valid_data.zip == "10003"
+        assert valid_data.commander_uid == "/officer/HUHH"
+
+
+

--- a/tests/fifty_a/fifty_a/spiders/test_command.py
+++ b/tests/fifty_a/fifty_a/spiders/test_command.py
@@ -19,21 +19,23 @@ class TestCommand:
         assert unit.url == mock_response.url
         assert unit.model == "unit"
         assert unit.source == "50-a.org"
-        
+
         try:
             valid_data = CreateUnit(**unit.data)
         except ValueError as e:
             pytest.fail(f"Unit Data is invalid: {e}")
 
         assert valid_data.name == "9th Precinct"
-        assert valid_data.website_url == "https://www1.nyc.gov/site/nypd/bureaus/patrol/precincts/9th-precinct.page"
+        assert valid_data.website_url == "https://www1.nyc.gov/" + \
+            "site/nypd/bureaus/patrol/precincts/9th-precinct.page"
         assert valid_data.phone == "(212) 477-7812"
-        assert valid_data.description == "The 9th Precinct serves the area from East Houston Street to East 14 Street from Broadway, to the East River in Manhattan. The precinct is home to the East Village, and features Tompkins Square Park."
+        assert valid_data.description == "The 9th Precinct serves " + \
+            "the area from East Houston Street to East 14 Street from " + \
+            "Broadway, to the East River in Manhattan. The precinct is" + \
+            " home to the East Village, and features Tompkins " + \
+            "Square Park."
         assert valid_data.address == "321 E 5th St"
         assert valid_data.city == "New York"
         assert valid_data.state == "NY"
         assert valid_data.zip == "10003"
         assert valid_data.commander_uid == "/officer/HUHH"
-
-
-


### PR DESCRIPTION
Updating the 50-a Scraper to use the new schemas outlined in the [NPDI API Documentation](https://npdindex.readme.io/reference/getofficerbyid).

Additionally:

- Adds a testing mode (scrapes only 10 random items rather than the entire site)
- Adds user agent data to identify the scrapper as coming from the [National Police Data Coalition](https://www.nationalpolicedata.org/).